### PR TITLE
added dockerfile

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,27 @@
+# simple multi-stage builder for go app
+
+#builder
+FROM golang:alpine as builder 
+
+RUN apk update && apk add --no-cache git
+RUN adduser -D -g '' gouser
+
+WORKDIR $GOPATH/src/go-web/main
+COPY ./main.go .
+
+RUN go get -d -v
+RUN go build -o /go/bin/go-web
+
+#final
+FROM alpine
+
+WORKDIR /webserver
+
+COPY --from=builder /go/bin/go-web /go/bin/go-web
+COPY --from=builder /etc/passwd /etc/passwd
+
+EXPOSE 8080
+
+USER gouser
+
+ENTRYPOINT /go/bin/go-web


### PR DESCRIPTION
I wrote a multi-stage dockerfile to build an image for the web server. 

Reference material: https://medium.com/@chemidy/create-the-smallest-and-secured-golang-docker-image-based-on-scratch-4752223b7324

This was tested to listen on port 8080. 
```
docker build -t local/go-web:alpine-test .
docker run -p 8080:8080 local/go-web:alpine-test
```